### PR TITLE
Stop to dump AST

### DIFF
--- a/src/compiler/parser/Compiler_parser.cpp
+++ b/src/compiler/parser/Compiler_parser.cpp
@@ -745,7 +745,7 @@ AST *Parser::parse(Tokens *tokens)
 		//dumpSyntax(root, 0);
 		Completer completer;
 		completer.complete(root);
-		dumpSyntax(root, 0);
+		//dumpSyntax(root, 0);
 		Node *last_stmt = _parse(root);
 		if (!last_stmt) Parser_exception("", 1);
 		return new AST(last_stmt->getRoot());


### PR DESCRIPTION
Now I am writing https://github.com/hatz48/perl2js which is a converter from Perl to JS. perl2js read Perl code from stdin or file, and output JavaScript code to stdout.
Compiler::Parser is awesome, but its C++ code dump AST to stdout too.

I think calling `dumpSyntax` is not intended, and I want to remove it.