### PR TITLE
Changed to sort by node name in rendering. (goccy/p5-Compiler-Parser#20)

### DIFF
--- a/lib/Compiler/Parser/AST/Renderer/Engine/Text.pm
+++ b/lib/Compiler/Parser/AST/Renderer/Engine/Text.pm
@@ -23,7 +23,7 @@ sub render {
 sub __render {
     my ($self, $nodes, $depth) = @_;
     my @names = keys %$nodes;
-    my @sorted_names = grep { $_ !~ /next/ } @names;
+    my @sorted_names = sort grep { $_ !~ /next/ } @names;
     push @sorted_names, 'next';
     foreach my $name (@sorted_names) {
         my $node = $nodes->{$name};


### PR DESCRIPTION
Order of renderer output is not fixed.
The order of <left> and <right> may change with each execution.